### PR TITLE
docs : add SECURITY.md to establish vulnerability policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in taiga-back, please report it emailing privately to: [security@taiga.io](mailto:security@taiga.io)
+
+Do not open public GitHub issues for security vulnerabilities. Public disclosure of detailed exploits can put users at risk.
+
+## How to Report
+
+Include as much detail as possible to help maintainers reproduce and fix the issue:
+
+- Clear description of the problem or vulnerability  
+- Steps to reproduce (if applicable)  
+- Expected vs. actual behavior  
+- Potential impact and severity  
+- Affected versions, configurations, or environments  
+- Logs, screenshots, OS versions or proof-of-concept (if available)  
+
+> Detailed reports help maintainers respond faster and release secure fixes.
+
+## Disclosure
+
+Do not disclose the issue publicly until it has been addressed.
+
+Allow maintainers reasonable time to investigate and resolve the problem before sharing details.
+
+## Scope
+
+This policy applies to the `taiga-back` repository.
+
+Thanks for helping keep Taiga secure.


### PR DESCRIPTION
## Objective 
#### This PR introduces a dedicated `SECURITY.md` file for the repository.

## Description
While security reporting instructions exist in the README, a standalone `SECURITY.md` ensures proper visibility, aligns with open-source security practices, and integrates with GitHub's security features.

## Why SECURITY.md?

1. **Prevent public disclosures:**  - GitHub detects `SECURITY.md` and warns users when opening issues, reducing accidental exposure.  
3. **Discoverability:**  - Security researchers and tools look for `SECURITY.md` in the root. 
4. **Security dashboard:** -  Activates the repository's Security tab and centralized policy management.  
5. **Separation of concerns:** -  Keeps the README focused on onboarding, general bugs and development setup.

## Changes

- Added `SECURITY.md` with reporting instructions and `security@taiga.io` contact.  
- Scoped the policy specifically to `taiga-back`.

> After merging, a follow-up PR can replace the README’s security section with a link to this file, creating a single source of truth.