### PR TITLE
fix(trello-importer): use sequential order values instead of raw list pos

### DIFF
--- a/taiga/importers/trello/importer.py
+++ b/taiga/importers/trello/importer.py
@@ -180,15 +180,16 @@ class TrelloImporter:
     def _import_project_data(self, data, options):
         board = data
         labels = board['labels']
-        statuses = board['lists']
+        # Sort by pos to preserve relative list order; Trello pos values can exceed
+        # PostgreSQL's integer max (2^31-1) on reordered boards, so we use sequential
+        # integers for order rather than the raw pos value.
+        statuses = sorted(board['lists'], key=lambda l: l['pos'])
         project_template = ProjectTemplate.objects.get(slug=options.get('template', "kanban"))
         project_template.us_statuses = []
-        counter = 0
-        for us_status in statuses:
-            if counter == 0:
+        for order, us_status in enumerate(statuses, start=1):
+            if not project_template.us_statuses:
                 project_template.default_options["us_status"] = us_status['name']
 
-            counter += 1
             if us_status['name'] not in [s['name'] for s in project_template.us_statuses]:
                 project_template.us_statuses.append({
                     "name": us_status['name'],
@@ -197,7 +198,7 @@ class TrelloImporter:
                     "is_archived": True if us_status['closed'] else False,
                     "color": "#999999",
                     "wip_limit": None,
-                    "order": us_status['pos'],
+                    "order": order,
                 })
 
         project_template.task_statuses = []

--- a/tests/integration/test_importers_trello_api.py
+++ b/tests/integration/test_importers_trello_api.py
@@ -17,6 +17,8 @@ from taiga.base.utils import json
 from taiga.base import exceptions as exc
 
 import taiga.importers.trello.importer
+from taiga.importers.trello.importer import TrelloImporter
+from taiga.projects.models import UserStoryStatus
 
 pytestmark = pytest.mark.django_db
 
@@ -257,3 +259,58 @@ def test_import_trello_project_with_celery_disabled(client, settings):
     assert response.status_code == 200
     assert "slug" in response.data
     assert response.data['slug'] == "imported-project"
+
+
+def test_import_project_large_list_positions_do_not_overflow(settings):
+    """
+    Trello list pos values can exceed PostgreSQL's integer max (~2.1 billion) on
+    boards that have been heavily reordered. The importer must use compact sequential
+    order values instead of passing pos directly, otherwise UserStoryStatus.objects.create
+    raises NumericValueOutOfRange and the import dies silently in the Celery worker.
+    """
+    settings.IMPORTERS = {"trello": {"api_key": "test-key", "secret_key": "test-secret"}}
+
+    user = f.UserFactory.create()
+    f.ProjectTemplateFactory.create(
+        slug="kanban",
+        roles=[{"name": "UX", "slug": "ux", "computable": True, "permissions": [], "order": 10}],
+        default_options={},
+    )
+
+    # pos values here are ~2^47, well above the PostgreSQL integer max of 2^31-1
+    board_data = {
+        "name": "Test Board",
+        "desc": "",
+        "labels": [],
+        "organization": None,
+        "lists": [
+            {"id": "aaa", "name": "To Do",      "pos": 140737488338944, "closed": False},
+            {"id": "bbb", "name": "In Progress", "pos": 140737488355328, "closed": False},
+            {"id": "ccc", "name": "Done",        "pos": 140737488371712, "closed": True},
+        ],
+        "cards": [],
+        "checklists": [],
+    }
+
+    options = {
+        "template": "kanban",
+        "name": None,
+        "description": None,
+        "is_private": False,
+        "users_bindings": {},
+        "keep_external_reference": False,
+    }
+
+    with mock.patch("taiga.importers.trello.importer.TrelloClient"):
+        importer = TrelloImporter(user, "token")
+
+    project = importer._import_project_data(board_data, options)
+
+    statuses = list(UserStoryStatus.objects.filter(project=project).order_by("order"))
+    assert len(statuses) == 3
+
+    # Relative order must match original pos ordering
+    assert [s.name for s in statuses] == ["To Do", "In Progress", "Done"]
+
+    # All order values must fit within PostgreSQL's integer range (max 2^31-1)
+    assert all(s.order < 2 ** 31 for s in statuses)


### PR DESCRIPTION
I ran into this while migrating some Trello boards to a self-hosted Taiga instance. A few of my boards had list \`pos\` values around 2^47 (e.g. \`140737488355328\`) — this seems to happen on boards that have been heavily reordered, or newer boards where Trello assigns positions in a different range.

The importer passes \`pos\` directly as \`order\` when building \`us_statuses\` in \`_import_project_data\`. Those values end up in a PostgreSQL \`integer\` column when \`apply_to_project\` creates the \`UserStoryStatus\` rows. PostgreSQL's \`integer\` type maxes out at 2^31 − 1 (~2.1 billion), so anything larger throws \`NumericValueOutOfRange\` and the import fails.

What makes this hard to spot: the failure happens inside the Celery worker, the \`taiga.importers.trello\` logger isn't wired to stdout in the default Docker setup, and the error email never arrives if SMTP isn't configured. From the user's perspective the project shell appears in the list but stays completely empty, with no indication of what went wrong.

The fix sorts the lists by their original \`pos\` first (to preserve relative order), then assigns compact sequential integers as \`order\` values instead of the raw Trello float. I've also replaced the \`counter\` variable with \`enumerate\` since I was touching those lines anyway.

To reproduce: try importing a Trello board whose lists have \`pos\` values above ~2.1 billion. You can check with the Trello API: \`GET https://api.trello.com/1/boards/{id}/lists?fields=name,pos\`.

---

**Testing:** There were no existing unit tests for \`_import_project_data\`, so I've added a regression test in \`tests/integration/test_importers_trello_api.py\`. It creates a minimal kanban template, feeds \`_import_project_data\` a board with ~2^47 \`pos\` values, and asserts that the resulting \`UserStoryStatus\` rows all have order values below 2^31.