### PR TITLE
taiga: make password recovery impossible for passwordless users

### DIFF
--- a/taiga/users/api.py
+++ b/taiga/users/api.py
@@ -163,6 +163,9 @@ class UsersViewSet(ModelCrudViewSet):
             raise exc.WrongArguments(_("Invalid username or email"))
 
         user = get_user_by_username_or_email(username_or_email)
+        if not user.has_usable_password()
+            raise exc.BadRequest(_("Password recovery not allowed for this user"))
+
         user.token = str(uuid.uuid4())
         user.save(update_fields=["token"])
 


### PR DESCRIPTION
This is a short fix to prevent users with no active password set for the used login scheme
to recover the password and therefor gain a second pair of login credentials.

This scenario can be a possible loophole to gain back access for users that where disabled
by LDAP e.g.