### PR TITLE
deps: bump pymdown-extensions to 10.21.3 (GHSA-62q4-447f-wv8h)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ pygments==2.19.2
     # via -r requirements.in
 pyjwt==2.10.1
     # via oauthlib
-pymdown-extensions==10.17.1
+pymdown-extensions==10.21.3
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
Updates `pymdown-extensions` to address GHSA-62q4-447f-wv8h (PYSEC-2026-2999, path traversal regression in `pymdownx.snippets`).

Evidence:
- `requirements.txt` pinned `pymdown-extensions==10.17.1`
- `osv-scanner --lockfile requirements.txt` reported PYSEC-2026-2999 / GHSA-62q4-447f-wv8h before the update
- updated version: `10.21.3`

Validation:
- `osv-scanner` no longer reports PYSEC-2026-2999 / GHSA-62q4-447f-wv8h after the update

Note: `osv-scanner` still reports separate advisories for `pymdown-extensions@10.21.3`: PYSEC-2026-3609 / GHSA-9xwg-3r6f-jcx2 and PYSEC-2026-3654 / GHSA-gm37-52c6-37mw. Those require the 11.x line (which needs python >=3.10 for >=3.10-only support), so this patch keeps the same 10.x line and only clears GHSA-62q4-447f-wv8h.

Scope: `requirements.txt` only (1-line pin bump).